### PR TITLE
KAN-145 fix: 회원탈퇴 및 사용자 상태 확인 버그 수정 및 안정화

### DIFF
--- a/src/main/java/com/spring/be/jwt/controller/AuthController.java
+++ b/src/main/java/com/spring/be/jwt/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.spring.be.jwt.controller;
 
 import com.spring.be.jwt.config.JwtUtils;
 import com.spring.be.jwt.service.AuthService;
+import com.spring.be.user.dto.UserResponseDto;
 import com.spring.be.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
@@ -46,5 +47,10 @@ public class AuthController {
     public ResponseEntity<?> googleLogout(@RequestHeader("Cookie") String cookieHeader) {
         String token = CookieUtils.extractTokenFromCookie(cookieHeader, "jwtToken");
         return authService.performGoogleLogout(token);
+    }
+
+    @GetMapping("/delete")
+    public ResponseEntity<?> deleteUser(@CookieValue("jwtToken") String jwtToken) {
+        return authService.deleteUser(jwtToken);
     }
 }

--- a/src/main/java/com/spring/be/jwt/controller/AuthController.java
+++ b/src/main/java/com/spring/be/jwt/controller/AuthController.java
@@ -1,13 +1,15 @@
 package com.spring.be.jwt.controller;
 
 import com.spring.be.jwt.config.JwtUtils;
+import com.spring.be.jwt.dto.CommonResponseDto;
+import com.spring.be.jwt.dto.LogoutResponseDto;
+import com.spring.be.jwt.dto.UserLoginStatusDto;
 import com.spring.be.jwt.service.AuthService;
 import com.spring.be.user.dto.UserResponseDto;
 import com.spring.be.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-import com.spring.be.util.CookieUtils;
 
 import java.util.Map;
 
@@ -32,25 +34,83 @@ public class AuthController {
     }
 
     @GetMapping("/status")
-    public ResponseEntity<?> checkLoginStatus(@RequestHeader("Cookie") String cookieHeader) {
-        String token = CookieUtils.extractTokenFromCookie(cookieHeader, "jwtToken");
-        return authService.checkLoginStatus(token);
+    public ResponseEntity<UserLoginStatusDto> checkLoginStatus(@CookieValue("jwtToken") String jwtToken) {
+        UserLoginStatusDto response = authService.checkLoginStatus(jwtToken);
+
+        if (!response.isLoggedIn()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        }
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout/kakao")
-    public ResponseEntity<?> kakaoLogout(@RequestHeader("Cookie") String cookieHeader) {
-        String token = CookieUtils.extractTokenFromCookie(cookieHeader, "jwtToken");
-        return authService.performKakaoLogout(token);
+    public ResponseEntity<CommonResponseDto> kakaoLogout(@CookieValue("jwtToken") String jwtToken) {
+        CommonResponseDto response = authService.performKakaoLogout(jwtToken);
+
+        if(!response.isSuccess()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        }
+
+        // 로그아웃 성공시 사용자 세션 및 쿠키 해제
+        ResponseCookie jwtCookie = ResponseCookie.from("jwtToken", "")
+                .httpOnly(false)// 테스트용 - false
+                .secure(true) // 필요에 따라 설정
+                .path("/")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
+                .body(response);
     }
 
     @PostMapping("/logout/google")
-    public ResponseEntity<?> googleLogout(@RequestHeader("Cookie") String cookieHeader) {
-        String token = CookieUtils.extractTokenFromCookie(cookieHeader, "jwtToken");
-        return authService.performGoogleLogout(token);
+    public ResponseEntity<CommonResponseDto> googleLogout(@CookieValue("jwtToken") String jwtToken) {
+        CommonResponseDto response = authService.performGoogleLogout(jwtToken);
+
+        if (!response.isSuccess()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
+
+        ResponseCookie jwtCookie = ResponseCookie.from("jwtToken", "")
+                .httpOnly(false)// 테스트용 - false
+                .secure(true) // 필요에 따라 설정
+                .path("/")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
+                .body(response);
     }
 
     @GetMapping("/delete")
-    public ResponseEntity<?> deleteUser(@CookieValue("jwtToken") String jwtToken) {
-        return authService.deleteUser(jwtToken);
+    public ResponseEntity<CommonResponseDto> deleteUser(@CookieValue("jwtToken") String jwtToken) {
+        CommonResponseDto response = authService.deleteUser(jwtToken);
+
+        if(!response.isSuccess()) {
+            if (response.getMessage().equals("Invalid user.")) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+            } else if (response.getMessage().equals("Unsupported platform.")) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            } else if (response.getMessage().equals("Logout failed.") || response.getMessage().equals("Failed to delete user.")) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            }
+        }
+
+        ResponseCookie jwtCookie = ResponseCookie.from("jwtToken", "")
+                .httpOnly(false)// 테스트용 - false
+                .secure(true) // 필요에 따라 설정
+                .path("/")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
+                .body(response);
     }
 }

--- a/src/main/java/com/spring/be/jwt/controller/GoogleAuthController.java
+++ b/src/main/java/com/spring/be/jwt/controller/GoogleAuthController.java
@@ -45,7 +45,7 @@ public class GoogleAuthController {
 
         // JWT 쿠키 설정
         ResponseCookie jwtCookie = ResponseCookie.from("jwtToken", responseDto.getJwtToken())
-                .httpOnly(true)
+                .httpOnly(false)// 테스트용 - false
                 .secure(false) // 필요에 따라 설정
                 .path("/")
                 .maxAge(60 * 60 * 24)
@@ -53,7 +53,7 @@ public class GoogleAuthController {
                 .build();
 
         return ResponseEntity.ok()
-                .header("Set-Cookie", jwtCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
                 .body(responseDto);
     }
 }

--- a/src/main/java/com/spring/be/jwt/dto/CommonResponseDto.java
+++ b/src/main/java/com/spring/be/jwt/dto/CommonResponseDto.java
@@ -1,0 +1,16 @@
+package com.spring.be.jwt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommonResponseDto {
+    private boolean success;
+    private String message;
+
+    public CommonResponseDto(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/spring/be/jwt/dto/LogoutResponseDto.java
+++ b/src/main/java/com/spring/be/jwt/dto/LogoutResponseDto.java
@@ -1,0 +1,16 @@
+package com.spring.be.jwt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LogoutResponseDto {
+    private boolean success;
+    private String message;
+
+    public LogoutResponseDto(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/spring/be/user/controller/UserController.java
+++ b/src/main/java/com/spring/be/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.spring.be.user.controller;
 
 import com.spring.be.entity.User;
 import com.spring.be.jwt.config.JwtUtils;
+import com.spring.be.jwt.service.AuthService;
 import com.spring.be.user.dto.UpdateProfileResponseDto;
 import com.spring.be.user.dto.UserActivityCountsDto;
 import com.spring.be.user.dto.UserResponseDto;
@@ -25,7 +26,6 @@ import java.util.Map;
 public class UserController {
 
     private final JwtUtils jwtUtils;
-    private final S3Service s3Service;
     private final UserService userService;
     private final UserRepository userRepository;
 
@@ -64,19 +64,6 @@ public class UserController {
         UserActivityCountsDto activityCounts = userService.getUserActivityCounts(userId);
         return ResponseEntity.ok(activityCounts);
     }
-
-    @GetMapping("/delete")
-    public ResponseEntity<UserResponseDto> deleteUser(@CookieValue("jwtToken") String jwtToken) {
-        BigInteger socialId = extractSocialIdFromCookie(jwtToken);
-
-        boolean isDeleted = userService.deleteUserBySocialId(socialId);
-
-        if (!isDeleted) {
-            return ResponseEntity.ok(new UserResponseDto(false, "User not found."));
-        }
-        return ResponseEntity.ok(new UserResponseDto(true, "User deleted successfully."));
-    }
-
 
     private BigInteger extractTokenFromCookie(String jwtToken) {
         if (jwtToken == null || jwtToken.isEmpty()) {

--- a/src/main/java/com/spring/be/user/dto/UserResponseDto.java
+++ b/src/main/java/com/spring/be/user/dto/UserResponseDto.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserResponseDto {
-    private boolean isLoggedIn;
+    private boolean success;
     private String message;
 }

--- a/src/main/java/com/spring/be/user/service/UserService.java
+++ b/src/main/java/com/spring/be/user/service/UserService.java
@@ -2,7 +2,10 @@ package com.spring.be.user.service;
 
 import com.spring.be.blogReview.service.BlogReviewService;
 import com.spring.be.entity.User;
+import com.spring.be.jwt.config.JwtUtils;
+import com.spring.be.jwt.service.AuthService;
 import com.spring.be.user.dto.UserActivityCountsDto;
+import com.spring.be.user.dto.UserResponseDto;
 import com.spring.be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -25,9 +28,15 @@ public class UserService {
         if (existingUser != null) {
             // 기존 사용자 정보 업데이트
             existingUser.setAccessToken(AccessToken);
+            if (existingUser.getDeletedAt() != null){
+                existingUser.setNickname(nickname);
+                existingUser.setUserImage(profileImage);
+            }
             existingUser.setDeletedAt(null);
             return userRepository.save(existingUser);
         }
+
+
         try {
             User newUser = new User(platform, socialId, nickname, profileImage, AccessToken, email);
             return userRepository.save(newUser);
@@ -64,9 +73,12 @@ public class UserService {
         if (user == null) {
             return false;
         }
-
+        user.setAccessToken(null);
         user.setDeletedAt(LocalDateTime.now());
         userRepository.save(user);
         return true;
     }
+
+
+
 }


### PR DESCRIPTION
### 🔗 관련 이슈
KAN-145

### 📌 작업 내용

- 회원 탈퇴 api 호출 로직 추가
- 회원 탈퇴시 유저 정보 리셋 (닉네임, 이미지)
- 로그인 api처리후 리다이렉트를 위한 로직 추가 

### 🧑‍💻 작업 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] CI/CD 변경

### 🚨 주의 사항
배포시에 배포를 위한 코드 수정이 필요함
-httpOnly 설정 변경 필요
-리다이렉트 관련 파라미터 스토어 값 변경 필요 

### ✅ 체크 리스트
- [x] 코드 리뷰어가 이해할 수 있도록 주석 및 설명을 추가했습니다.
- [ ] 테스트를 추가하거나 업데이트 했습니다.
- [x] 이 변경 사항이 다른 기능에 영향을 미치는지 확인했습니다.
